### PR TITLE
fix: migrate language server to lsp-types 0.97 (Url -> Uri)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,6 +175,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -226,6 +237,15 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "getrandom"
@@ -289,10 +309,113 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -335,6 +458,12 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "log"
@@ -408,6 +537,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "ureq",
+ "url",
  "walkdir",
 ]
 
@@ -416,6 +546,15 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "prettyplease"
@@ -595,6 +734,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -618,6 +769,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -628,6 +790,16 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -678,10 +850,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
 name = "utf8-zero"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -958,10 +1148,93 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ lsp-types = "0.97.0"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
 ureq = "3"
+url = "2"
 walkdir = "2.5.0"
 
 [profile.release]

--- a/src/server/code_actions.rs
+++ b/src/server/code_actions.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 
 use lsp_types::{
     CodeAction, CodeActionOrCommand, CodeActionParams, CodeActionResponse, Command, Diagnostic,
-    NumberOrString, Position, Range, TextEdit, Url, WorkspaceEdit,
+    NumberOrString, Position, Range, TextEdit, Uri, WorkspaceEdit,
 };
 
 use crate::server::diagnostics::DIAGNOSTIC_SOURCE;
@@ -62,7 +62,7 @@ fn owui_rule_id(diagnostic: &Diagnostic) -> Option<&str> {
 }
 
 fn fix_for_rule(
-    uri: &Url,
+    uri: &Uri,
     lines: &[&str],
     diagnostic: &Diagnostic,
     rule_id: &str,
@@ -81,7 +81,7 @@ fn fix_for_rule(
 }
 
 fn async_fix(
-    uri: &Url,
+    uri: &Uri,
     lines: &[&str],
     diagnostic: &Diagnostic,
     line_idx: usize,
@@ -97,7 +97,7 @@ fn async_fix(
 }
 
 fn docstring_fix(
-    uri: &Url,
+    uri: &Uri,
     lines: &[&str],
     diagnostic: &Diagnostic,
     line_idx: usize,
@@ -126,7 +126,7 @@ fn docstring_fix(
 }
 
 fn header_field_fix(
-    uri: &Url,
+    uri: &Uri,
     lines: &[&str],
     diagnostic: &Diagnostic,
     docstring_line_idx: usize,
@@ -166,8 +166,8 @@ fn header_field_fix(
     Some(quickfix(uri, &title, diagnostic, edit))
 }
 
-fn quickfix(uri: &Url, title: &str, diagnostic: &Diagnostic, edit: TextEdit) -> CodeAction {
-    let mut changes: HashMap<Url, Vec<TextEdit>> = HashMap::new();
+fn quickfix(uri: &Uri, title: &str, diagnostic: &Diagnostic, edit: TextEdit) -> CodeAction {
+    let mut changes: HashMap<Uri, Vec<TextEdit>> = HashMap::new();
     changes.insert(uri.clone(), vec![edit]);
     CodeAction {
         title: title.to_string(),
@@ -228,14 +228,16 @@ pub fn disable_rule_in_config(root: &Path, rule_id: &str) -> std::io::Result<Pat
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     use super::*;
     use lsp_types::{
         CodeActionContext, CodeActionParams, NumberOrString, PartialResultParams,
         TextDocumentIdentifier, WorkDoneProgressParams,
     };
 
-    fn uri() -> Url {
-        Url::parse("file:///tmp/owui_code_action_test.py").expect("valid uri")
+    fn uri() -> Uri {
+        Uri::from_str("file:///tmp/owui_code_action_test.py").expect("valid uri")
     }
 
     /// Build an owui-lint diagnostic for `rule_id` anchored at `line` (0-indexed).

--- a/src/server/completions.rs
+++ b/src/server/completions.rs
@@ -185,10 +185,12 @@ fn class_member_items() -> Vec<CompletionItem> {
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     use super::*;
     use lsp_types::{
         CompletionParams, PartialResultParams, Position, TextDocumentIdentifier,
-        TextDocumentPositionParams, Url, WorkDoneProgressParams,
+        TextDocumentPositionParams, Uri, WorkDoneProgressParams,
     };
 
     const MULTILINE_DOC: &str =
@@ -228,7 +230,7 @@ mod tests {
     }
 
     fn completion_at(source: &str, line: u32) -> Vec<CompletionItem> {
-        let uri = Url::parse("file:///tmp/owui_completion_test.py").expect("valid uri");
+        let uri = Uri::from_str("file:///tmp/owui_completion_test.py").expect("valid uri");
         let mut state = ServerState::new(None);
         state.upsert(uri.clone(), source.to_string(), 1);
 
@@ -281,7 +283,7 @@ mod tests {
 
     #[test]
     fn completion_none_for_unknown_document() {
-        let uri = Url::parse("file:///tmp/owui_unknown.py").expect("valid uri");
+        let uri = Uri::from_str("file:///tmp/owui_unknown.py").expect("valid uri");
         let state = ServerState::new(None);
         let params = CompletionParams {
             text_document_position: TextDocumentPositionParams {

--- a/src/server/diagnostics.rs
+++ b/src/server/diagnostics.rs
@@ -1,5 +1,7 @@
+use std::str::FromStr;
+
 use lsp_types::{
-    CodeDescription, Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range, Url,
+    CodeDescription, Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range, Uri,
 };
 
 use crate::models::{Issue, Severity};
@@ -39,7 +41,7 @@ fn issue_to_diagnostic(issue: &Issue, lines: &[&str]) -> Diagnostic {
     };
 
     let code_description = rule_doc(issue.rule_id)
-        .and_then(|doc| Url::parse(doc.help_url).ok())
+        .and_then(|doc| Uri::from_str(doc.help_url).ok())
         .map(|href| CodeDescription { href });
 
     Diagnostic {

--- a/src/server/hover.rs
+++ b/src/server/hover.rs
@@ -46,10 +46,12 @@ fn render_issue(issue: &Issue) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     use super::*;
     use crate::server::state::ServerState;
     use lsp_types::{
-        Position, TextDocumentIdentifier, TextDocumentPositionParams, Url, WorkDoneProgressParams,
+        Position, TextDocumentIdentifier, TextDocumentPositionParams, Uri, WorkDoneProgressParams,
     };
 
     // `def search` (line 2, 1-indexed) triggers OWT101/OWT102; `return query`
@@ -57,7 +59,7 @@ mod tests {
     const TOOLS_SOURCE: &str = "class Tools:\n    def search(self, query):\n        return query\n";
 
     fn hover_at(source: &str, line: u32) -> Option<Hover> {
-        let uri = Url::parse("file:///tmp/owui_hover_test.py").expect("valid uri");
+        let uri = Uri::from_str("file:///tmp/owui_hover_test.py").expect("valid uri");
         let mut state = ServerState::new(None);
         state.upsert(uri.clone(), source.to_string(), 1);
 
@@ -94,7 +96,7 @@ mod tests {
 
     #[test]
     fn hover_none_for_unknown_document() {
-        let uri = Url::parse("file:///tmp/owui_hover_missing.py").expect("valid uri");
+        let uri = Uri::from_str("file:///tmp/owui_hover_missing.py").expect("valid uri");
         let state = ServerState::new(None);
         let params = HoverParams {
             text_document_position_params: TextDocumentPositionParams {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -4,6 +4,11 @@
 //! is editing and complements (does not replace) a general Python language
 //! server such as Pylance/Pyright. It speaks LSP over stdio via `lsp-server`.
 
+// `lsp_types::Uri` (fluent-uri) carries an internal cache cell, so Clippy's
+// `mutable_key_type` lint fires when we key maps by it. Its `Hash`/`Eq` use the
+// stable string form (`as_str()`), so using it as a map key is sound.
+#![allow(clippy::mutable_key_type)]
+
 mod code_actions;
 mod completions;
 mod diagnostics;
@@ -25,14 +30,14 @@ use lsp_types::{
     DidCloseTextDocumentParams, DidOpenTextDocumentParams, ExecuteCommandOptions,
     ExecuteCommandParams, HoverProviderCapability, InitializeParams, MessageType,
     PublishDiagnosticsParams, ServerCapabilities, ShowMessageParams, TextDocumentSyncCapability,
-    TextDocumentSyncKind, Url,
+    TextDocumentSyncKind, Uri,
 };
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 
 use crate::server::code_actions::{DISABLE_RULE_COMMAND, disable_rule_in_config};
 use crate::server::diagnostics::issues_to_diagnostics;
-use crate::server::state::ServerState;
+use crate::server::state::{ServerState, uri_to_file_path};
 
 /// Run the language server over stdio until the client shuts it down.
 pub fn run() -> Result<()> {
@@ -81,15 +86,12 @@ fn server_capabilities() -> ServerCapabilities {
 fn workspace_root(params: &InitializeParams) -> Option<std::path::PathBuf> {
     if let Some(folders) = &params.workspace_folders
         && let Some(first) = folders.first()
-        && let Ok(path) = first.uri.to_file_path()
+        && let Some(path) = uri_to_file_path(&first.uri)
     {
         return Some(path);
     }
     #[allow(deprecated)]
-    params
-        .root_uri
-        .as_ref()
-        .and_then(|uri| uri.to_file_path().ok())
+    params.root_uri.as_ref().and_then(uri_to_file_path)
 }
 
 fn main_loop(connection: &Connection, state: &mut ServerState) -> Result<()> {
@@ -238,7 +240,7 @@ fn handle_execute_command(
     Ok(())
 }
 
-fn publish_diagnostics(connection: &Connection, state: &ServerState, uri: &Url) -> Result<()> {
+fn publish_diagnostics(connection: &Connection, state: &ServerState, uri: &Uri) -> Result<()> {
     let Some(document) = state.document(uri) else {
         return Ok(());
     };
@@ -248,7 +250,7 @@ fn publish_diagnostics(connection: &Connection, state: &ServerState, uri: &Url) 
 
 fn publish_for(
     connection: &Connection,
-    uri: &Url,
+    uri: &Uri,
     diagnostics: Vec<lsp_types::Diagnostic>,
     version: Option<i32>,
 ) -> Result<()> {

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
-use lsp_types::Url;
+use lsp_types::Uri;
 
 use crate::config::{Config, load_config_in_dir};
 use crate::linter::lint_source;
@@ -22,7 +22,7 @@ pub struct Document {
 /// Mutable server state: open documents plus the workspace configuration.
 #[derive(Debug)]
 pub struct ServerState {
-    documents: HashMap<Url, Document>,
+    documents: HashMap<Uri, Document>,
     root: Option<PathBuf>,
     config: Config,
 }
@@ -52,16 +52,16 @@ impl ServerState {
         self.root.as_deref()
     }
 
-    pub fn document(&self, uri: &Url) -> Option<&Document> {
+    pub fn document(&self, uri: &Uri) -> Option<&Document> {
         self.documents.get(uri)
     }
 
     /// All currently open document URIs (used to refresh diagnostics).
-    pub fn open_uris(&self) -> Vec<Url> {
+    pub fn open_uris(&self) -> Vec<Uri> {
         self.documents.keys().cloned().collect()
     }
 
-    pub fn upsert(&mut self, uri: Url, text: String, version: i32) {
+    pub fn upsert(&mut self, uri: Uri, text: String, version: i32) {
         let issues = lint_source(&uri_to_path(&uri), &text, &self.config);
         self.documents.insert(
             uri,
@@ -76,13 +76,13 @@ impl ServerState {
     /// Record a new document version without changing its text or re-linting.
     /// Used for `didChange` notifications that carry no content (FULL sync still
     /// advances the version even when the text is unchanged).
-    pub fn set_version(&mut self, uri: &Url, version: i32) {
+    pub fn set_version(&mut self, uri: &Uri, version: i32) {
         if let Some(document) = self.documents.get_mut(uri) {
             document.version = version;
         }
     }
 
-    pub fn remove(&mut self, uri: &Url) {
+    pub fn remove(&mut self, uri: &Uri) {
         self.documents.remove(uri);
     }
 
@@ -102,20 +102,34 @@ impl ServerState {
     }
 }
 
+/// Convert a `file://` URI to a real filesystem path, or `None` for non-file
+/// URIs. `lsp_types::Uri` (fluent-uri) has no path conversion, so we go through
+/// the `url` crate which handles percent-decoding and platform-specific paths.
+pub fn uri_to_file_path(uri: &Uri) -> Option<PathBuf> {
+    url::Url::parse(uri.as_str())
+        .ok()
+        .and_then(|url| url.to_file_path().ok())
+}
+
 /// Convert a `file://` URI to a filesystem path. Diagnostics need a path so the
 /// analyzer can resolve the extension type; for non-file URIs we fall back to a
 /// best-effort path derived from the URI itself.
-pub fn uri_to_path(uri: &Url) -> PathBuf {
-    uri.to_file_path()
-        .unwrap_or_else(|_| PathBuf::from(uri.path()))
+pub fn uri_to_path(uri: &Uri) -> PathBuf {
+    uri_to_file_path(uri).unwrap_or_else(|| {
+        url::Url::parse(uri.as_str())
+            .map(|url| PathBuf::from(url.path()))
+            .unwrap_or_else(|_| PathBuf::from(uri.as_str()))
+    })
 }
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     use super::*;
 
-    fn uri(s: &str) -> Url {
-        Url::parse(s).expect("valid uri")
+    fn uri(s: &str) -> Uri {
+        Uri::from_str(s).expect("valid uri")
     }
 
     #[test]

--- a/tests/server_tests.rs
+++ b/tests/server_tests.rs
@@ -1,5 +1,9 @@
+// `lsp_types::Uri` keys (see note in `src/server/mod.rs`).
+#![allow(clippy::mutable_key_type)]
+
 use std::collections::HashMap;
 use std::path::Path;
+use std::str::FromStr;
 use std::thread::JoinHandle;
 use std::time::Duration;
 
@@ -8,7 +12,7 @@ use lsp_types::{
     CodeAction, CodeActionContext, CodeActionOrCommand, CodeActionParams, CodeActionResponse,
     Diagnostic, DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
     ExecuteCommandParams, InitializeParams, NumberOrString, PublishDiagnosticsParams,
-    TextDocumentContentChangeEvent, TextDocumentIdentifier, TextDocumentItem, Url,
+    TextDocumentContentChangeEvent, TextDocumentIdentifier, TextDocumentItem, Uri,
     VersionedTextDocumentIdentifier,
 };
 
@@ -39,7 +43,7 @@ fn server_publishes_diagnostics_and_offers_quick_fix() {
     send_notification(&client_conn, "initialized", serde_json::json!({}));
 
     // --- open a Tools document ---
-    let uri = Url::parse("file:///tmp/owui_lsp_test_tools.py").expect("valid uri");
+    let uri = Uri::from_str("file:///tmp/owui_lsp_test_tools.py").expect("valid uri");
     send_notification(
         &client_conn,
         "textDocument/didOpen",
@@ -140,8 +144,8 @@ fn execute_command_disables_rule_and_refreshes_open_documents() {
     handshake(&client, Some(workspace.path()));
 
     // Open two Tools documents; both report OWT102.
-    let uri_a = Url::parse("file:///tmp/owui_cmd_a.py").expect("uri a");
-    let uri_b = Url::parse("file:///tmp/owui_cmd_b.py").expect("uri b");
+    let uri_a = Uri::from_str("file:///tmp/owui_cmd_a.py").expect("uri a");
+    let uri_b = Uri::from_str("file:///tmp/owui_cmd_b.py").expect("uri b");
     open_document(&client, &uri_a, TOOLS_SOURCE);
     assert!(
         codes(&recv_publish(&client).diagnostics).contains(&"OWT102".to_string()),
@@ -167,7 +171,7 @@ fn execute_command_disables_rule_and_refreshes_open_documents() {
     );
 
     // The server republishes diagnostics for both open documents before replying.
-    let mut refreshed: HashMap<Url, Vec<String>> = HashMap::new();
+    let mut refreshed: HashMap<Uri, Vec<String>> = HashMap::new();
     for _ in 0..2 {
         let params = recv_publish(&client);
         refreshed.insert(params.uri, codes(&params.diagnostics));
@@ -178,12 +182,12 @@ fn execute_command_disables_rule_and_refreshes_open_documents() {
         let codes = refreshed.get(uri).expect("refreshed diagnostics for doc");
         assert!(
             !codes.contains(&"OWT102".to_string()),
-            "OWT102 should be silenced for {uri} after disable, got {codes:?}"
+            "OWT102 should be silenced for {uri:?} after disable, got {codes:?}"
         );
         // OWT101 is unaffected, proving we re-linted rather than cleared.
         assert!(
             codes.contains(&"OWT101".to_string()),
-            "OWT101 should remain for {uri}, got {codes:?}"
+            "OWT101 should remain for {uri:?}, got {codes:?}"
         );
     }
 
@@ -201,7 +205,7 @@ fn did_change_relints_updated_buffer() {
     let (client, server) = spawn_server();
     handshake(&client, None);
 
-    let uri = Url::parse("file:///tmp/owui_change.py").expect("uri");
+    let uri = Uri::from_str("file:///tmp/owui_change.py").expect("uri");
     open_document(&client, &uri, TOOLS_SOURCE);
     assert!(
         codes(&recv_publish(&client).diagnostics).contains(&"OWT102".to_string()),
@@ -244,7 +248,7 @@ fn did_close_clears_diagnostics() {
     let (client, server) = spawn_server();
     handshake(&client, None);
 
-    let uri = Url::parse("file:///tmp/owui_close.py").expect("uri");
+    let uri = Uri::from_str("file:///tmp/owui_close.py").expect("uri");
     open_document(&client, &uri, TOOLS_SOURCE);
     assert!(
         !recv_publish(&client).diagnostics.is_empty(),
@@ -292,13 +296,24 @@ fn spawn_server() -> (Connection, JoinHandle<()>) {
     (client_conn, server)
 }
 
+/// Build a `file://` URI from a filesystem path. `lsp_types::Uri` (fluent-uri)
+/// has no path constructor, so go through the `url` crate.
+fn file_uri(path: &Path) -> Uri {
+    Uri::from_str(
+        url::Url::from_file_path(path)
+            .expect("absolute file path")
+            .as_str(),
+    )
+    .expect("valid file uri")
+}
+
 /// Perform the initialize/initialized handshake, optionally advertising a
 /// workspace root (needed for config-writing commands).
 fn handshake(client: &Connection, root: Option<&Path>) {
     let init_id = RequestId::from(1);
     #[allow(deprecated)]
     let params = InitializeParams {
-        root_uri: root.map(|path| Url::from_file_path(path).expect("file uri for root")),
+        root_uri: root.map(file_uri),
         ..InitializeParams::default()
     };
     send_request(client, init_id.clone(), "initialize", params);
@@ -307,7 +322,7 @@ fn handshake(client: &Connection, root: Option<&Path>) {
 }
 
 /// Open a document and let the server lint it.
-fn open_document(client: &Connection, uri: &Url, text: &str) {
+fn open_document(client: &Connection, uri: &Uri, text: &str) {
     send_notification(
         client,
         "textDocument/didOpen",
@@ -337,7 +352,7 @@ fn shutdown(client: &Connection, server: JoinHandle<()>, id: i32) {
 }
 
 /// Pull the first `TextEdit` a code action applies to `uri`.
-fn first_text_edit(action: &CodeAction, uri: &Url) -> lsp_types::TextEdit {
+fn first_text_edit(action: &CodeAction, uri: &Uri) -> lsp_types::TextEdit {
     action
         .edit
         .as_ref()


### PR DESCRIPTION
The `lsp-types` 0.97 bump (#42) was a breaking API change (`Url` → fluent-uri `Uri`, no `to_file_path`/`from_file_path`) that broke the build, so the v0.6.2 release matrix failed. This migrates the language server to the new API.

## Changes
- Replace `lsp_types::Url` with `lsp_types::Uri` across the server + tests; parse via `Uri::from_str`.
- Add `url` as a direct dependency and route file-path ↔ URI conversion through it (`uri_to_file_path` / `uri_to_path`); tests use a small `file_uri` helper.
- `#[allow(clippy::mutable_key_type)]` where `Uri` keys maps (Hash/Eq use the stable string form).

## Verification
- `cargo build`, `cargo clippy --locked --all-targets -- -D warnings`, `cargo test --locked`, `make docs-check` all pass locally.

Cuts a `fix:` release → release-please will produce **v0.6.3** with working binaries + `.vsix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)