### PR TITLE
feat(server): LSP 3.17 pull diagnostics, logMessage logging, and editor setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,8 @@ The repository also ships a VS Code extension as a `.vsix` release asset. Instal
 
 The extension adds Open WebUI-specific diagnostics, hover details, completions, and quick fixes. It complements Pylance/Pyright; it does not replace general Python syntax checking or IntelliSense.
 
+Diagnostics are available both as push (`textDocument/publishDiagnostics`) and the LSP 3.17 pull model (`textDocument/diagnostic`), so modern clients can fetch findings on demand; the server re-triggers pull clients after project-wide changes (`workspace/diagnostic/refresh`).
+
 If the binary is not on your `PATH`, configure:
 
 ```jsonc

--- a/docs/src/content/docs/editor-integration.md
+++ b/docs/src/content/docs/editor-integration.md
@@ -9,9 +9,11 @@ description: Use owui-lint as an LSP server.
 owui-lint server
 ```
 
-The server provides Open WebUI-specific intelligence on top of a general Python language server (Pylance/Pyright); it does not replace general Python tooling.
+The server provides Open WebUI-specific intelligence on top of a general Python language server (Pylance/Pyright); it does not replace general Python tooling. It identifies itself to the client via `serverInfo` (`owui-lint` plus the binary version).
 
-- **Diagnostics** — the same rule engine used by the CLI; published on open/change, cleared on close.
+- **Diagnostics** — the same rule engine used by the CLI, offered both ways:
+  - *Push* — published on open/change and cleared on close (`textDocument/publishDiagnostics`).
+  - *Pull* — computed on demand via the LSP 3.17 pull model (`textDocument/diagnostic`); clients that prefer pull use this and ignore the push. After a project-wide change such as disabling a rule, the server asks pull-model clients to re-query (`workspace/diagnostic/refresh`).
 - **Hover** — on a finding line: rule title, summary, **Fix:** remediation, a `[Documentation](url)` link, and the minimum Open WebUI version required.
 - **Completions** — Open WebUI scaffolding snippets for Python files, selected by cursor context:
   - *Inside the module docstring* — header field snippets: `version`, `title`, `requirements`, `author`, `description`.

--- a/docs/src/content/docs/editor-integration.md
+++ b/docs/src/content/docs/editor-integration.md
@@ -20,6 +20,7 @@ The server provides Open WebUI-specific intelligence on top of a general Python 
   - *At top level (no indentation)* — class skeleton snippets: `owui-tools`, `owui-pipe`, `owui-filter`, `owui-action`, `owui-pipeline`.
   - *Inside a class body (indented)* — class member snippets: `Valves`, `UserValves`, `pipe-method`, `inlet-method`, `outlet-method`, `action-method`.
 - **Quick fixes** — make a handler `async` (OWT102, OWP202, OWA401), add a docstring stub (OWT101), add a missing module-header field (OWUI030 `version`, OWUI032 `title`), or disable a rule for the project.
+- **Logging** — operational events (startup, per-file lint summaries, recoverable errors) are sent via `window/logMessage` to the editor's output channel, filtered by the client's log/trace level.
 
 ## VS Code Extension
 
@@ -52,9 +53,11 @@ If VS Code cannot find the binary, set `owui-lint.path` to an absolute path.
 ### Commands
 
 - **owui-lint: Restart Language Server** (`owui-lint.restartServer`) — stops and restarts the language server process without reloading VS Code.
+- **owui-lint: Show Output** (`owui-lint.showOutput`) — reveals the server's output channel, where `window/logMessage` entries and (when `owui-lint.trace.server` is `messages`/`verbose`) the LSP message trace appear.
 
 ### Troubleshooting
 
+- For a closer look at what the server is doing, run **owui-lint: Show Output** and set `owui-lint.trace.server` to `messages` or `verbose`.
 - If no diagnostics appear, confirm the file language mode is Python and run `owui-lint path/to/file.py` in a terminal.
 - If the server cannot start, set `owui-lint.path` to the absolute binary path and run **owui-lint: Restart Language Server**.
 - If Python syntax errors are missing, enable a Python language server such as Pylance or Pyright; `owui-lint` only reports Open WebUI-specific issues.

--- a/docs/src/content/docs/editor-integration.md
+++ b/docs/src/content/docs/editor-integration.md
@@ -75,10 +75,132 @@ Press <kbd>F5</kbd> in VS Code to launch an Extension Development Host.
 
 ## Other Editors
 
-Any editor with a generic LSP client (Neovim, Helix, Zed, etc.) can run the server over stdio. Configure the command as:
+Any editor with a generic LSP client can run owui-lint over stdio. The recipe is
+always the same:
 
-```text
-owui-lint server
+- **Command:** `owui-lint server`
+- **File types:** `python`
+- **Root markers:** `config.yml`, `owui-lint.yml` (or `.git`) — the server reads the workspace [configuration](configuration/) from here.
+
+No `initializationOptions` are required. owui-lint is meant to run **alongside** a
+general Python language server (Pyright, Pylsp, Jedi); enable both wherever the
+client supports multiple servers for one file type.
+
+### Neovim (built-in, 0.11+)
+
+No plugin needed. In your `init.lua`:
+
+```lua
+vim.lsp.config("owui_lint", {
+  cmd = { "owui-lint", "server" },
+  filetypes = { "python" },
+  root_markers = { "config.yml", "owui-lint.yml", ".git" },
+})
+vim.lsp.enable("owui_lint")
 ```
 
-Diagnostics use the workspace configuration discovered by the CLI config loader.
+### Neovim (nvim-lspconfig)
+
+owui-lint is not in the lspconfig registry, so register it as a custom server:
+
+```lua
+local lspconfig = require("lspconfig")
+local configs = require("lspconfig.configs")
+
+if not configs.owui_lint then
+  configs.owui_lint = {
+    default_config = {
+      cmd = { "owui-lint", "server" },
+      filetypes = { "python" },
+      root_dir = lspconfig.util.root_pattern("config.yml", "owui-lint.yml", ".git"),
+      single_file_support = true,
+    },
+  }
+end
+
+lspconfig.owui_lint.setup({})
+```
+
+### Vim (vim-lsp)
+
+```vim
+if executable('owui-lint')
+  augroup owui_lint
+    autocmd!
+    autocmd User lsp_setup call lsp#register_server({
+          \ 'name': 'owui-lint',
+          \ 'cmd': {server_info->['owui-lint', 'server']},
+          \ 'allowlist': ['python'],
+          \ })
+  augroup END
+endif
+```
+
+### Vim/Neovim (coc.nvim)
+
+In `coc-settings.json`:
+
+```jsonc
+{
+  "languageserver": {
+    "owui-lint": {
+      "command": "owui-lint",
+      "args": ["server"],
+      "filetypes": ["python"],
+      "rootPatterns": ["config.yml", "owui-lint.yml", ".git"]
+    }
+  }
+}
+```
+
+### Helix
+
+In `languages.toml` (keep your existing Python server in the list):
+
+```toml
+[language-server.owui-lint]
+command = "owui-lint"
+args = ["server"]
+
+[[language]]
+name = "python"
+language-servers = ["pyright", "owui-lint"]
+```
+
+### Sublime Text (LSP package)
+
+In `LSP.sublime-settings`:
+
+```jsonc
+{
+  "clients": {
+    "owui-lint": {
+      "enabled": true,
+      "command": ["owui-lint", "server"],
+      "selector": "source.python"
+    }
+  }
+}
+```
+
+### Emacs (Eglot)
+
+```elisp
+(with-eval-after-load 'eglot
+  (add-to-list 'eglot-server-programs
+               '((python-mode python-ts-mode) . ("owui-lint" "server"))))
+```
+
+Eglot runs a single server per buffer, so this **replaces** your Python server.
+To run owui-lint and Pyright together, use `lsp-mode`, which supports multiple
+servers for one major mode.
+
+### Verifying
+
+These clients drive diagnostics over the push model
+(`textDocument/publishDiagnostics`) or the LSP 3.17 pull model
+(`textDocument/diagnostic`) — owui-lint supports both, so use whichever your
+client prefers. To confirm the server is running, open a Python file with an
+Open WebUI extension and check that `OWUI*`/`OWT*`/`OWP*`/`OWF*`/`OWA*`/`OWPL*`
+findings appear; if not, run `owui-lint path/to/file.py` in a terminal to verify
+the binary and your configuration.

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -22,6 +22,10 @@
       {
         "command": "owui-lint.restartServer",
         "title": "owui-lint: Restart Language Server"
+      },
+      {
+        "command": "owui-lint.showOutput",
+        "title": "owui-lint: Show Output"
       }
     ],
     "configuration": {

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -14,6 +14,11 @@ export function activate(context: vscode.ExtensionContext): void {
     vscode.commands.registerCommand("owui-lint.restartServer", async () => {
       await restart(context);
     }),
+    // Reveal the server's output channel, where window/logMessage entries
+    // (startup, lint summaries, errors) and LSP message traces appear.
+    vscode.commands.registerCommand("owui-lint.showOutput", () => {
+      client?.outputChannel.show();
+    }),
   );
   client.start();
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -23,20 +23,24 @@ use lsp_types::notification::{
     PublishDiagnostics, ShowMessage,
 };
 use lsp_types::request::{
-    CodeActionRequest, Completion, ExecuteCommand, HoverRequest, Request as _,
+    CodeActionRequest, Completion, DocumentDiagnosticRequest, ExecuteCommand, HoverRequest,
+    Request as _, WorkspaceDiagnosticRefresh,
 };
 use lsp_types::{
-    CodeActionProviderCapability, CompletionOptions, DidChangeTextDocumentParams,
-    DidCloseTextDocumentParams, DidOpenTextDocumentParams, ExecuteCommandOptions,
-    ExecuteCommandParams, HoverProviderCapability, InitializeParams, MessageType,
-    PublishDiagnosticsParams, ServerCapabilities, ShowMessageParams, TextDocumentSyncCapability,
-    TextDocumentSyncKind, Uri,
+    CodeActionProviderCapability, CompletionOptions, DiagnosticOptions,
+    DiagnosticServerCapabilities, DidChangeTextDocumentParams, DidCloseTextDocumentParams,
+    DidOpenTextDocumentParams, DocumentDiagnosticParams, DocumentDiagnosticReport,
+    DocumentDiagnosticReportResult, ExecuteCommandOptions, ExecuteCommandParams,
+    FullDocumentDiagnosticReport, HoverProviderCapability, InitializeParams, InitializeResult,
+    MessageType, PublishDiagnosticsParams, RelatedFullDocumentDiagnosticReport, ServerCapabilities,
+    ServerInfo, ShowMessageParams, TextDocumentSyncCapability, TextDocumentSyncKind, Uri,
+    WorkDoneProgressOptions,
 };
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 
 use crate::server::code_actions::{DISABLE_RULE_COMMAND, disable_rule_in_config};
-use crate::server::diagnostics::issues_to_diagnostics;
+use crate::server::diagnostics::{DIAGNOSTIC_SOURCE, issues_to_diagnostics};
 use crate::server::state::{ServerState, uri_to_file_path};
 
 /// Run the language server over stdio until the client shuts it down.
@@ -54,16 +58,41 @@ pub fn run() -> Result<()> {
 /// Decoupled from `Connection::stdio()` so tests can drive the server through an
 /// in-memory connection (`Connection::memory()`).
 pub fn serve(connection: &Connection) -> Result<()> {
-    let capabilities = serde_json::to_value(server_capabilities())
-        .context("failed to serialize server capabilities")?;
-    let init_params = connection
-        .initialize(capabilities)
+    // Drive the handshake by hand (rather than `Connection::initialize`) so the
+    // `InitializeResult` can carry `serverInfo` and so we can read the client's
+    // capabilities to decide which optional features to use.
+    let (id, params) = connection
+        .initialize_start()
         .context("LSP initialize handshake failed")?;
     let init_params: InitializeParams =
-        serde_json::from_value(init_params).context("invalid InitializeParams")?;
+        serde_json::from_value(params).context("invalid InitializeParams")?;
+
+    let result = InitializeResult {
+        capabilities: server_capabilities(),
+        server_info: Some(ServerInfo {
+            name: env!("CARGO_PKG_NAME").to_string(),
+            version: Some(env!("CARGO_PKG_VERSION").to_string()),
+        }),
+    };
+    connection
+        .initialize_finish(id, serde_json::to_value(result)?)
+        .context("LSP initialize handshake failed")?;
 
     let mut state = ServerState::new(workspace_root(&init_params));
+    state.set_diagnostic_refresh_support(client_supports_diagnostic_refresh(&init_params));
     main_loop(connection, &mut state)
+}
+
+/// Whether the client advertised `workspace.diagnostic.refreshSupport`, meaning
+/// it can handle a server-sent `workspace/diagnostic/refresh` request.
+fn client_supports_diagnostic_refresh(params: &InitializeParams) -> bool {
+    params
+        .capabilities
+        .workspace
+        .as_ref()
+        .and_then(|workspace| workspace.diagnostic.as_ref())
+        .and_then(|diagnostic| diagnostic.refresh_support)
+        .unwrap_or(false)
 }
 
 fn server_capabilities() -> ServerCapabilities {
@@ -79,6 +108,16 @@ fn server_capabilities() -> ServerCapabilities {
             commands: vec![DISABLE_RULE_COMMAND.to_string()],
             ..ExecuteCommandOptions::default()
         }),
+        // Pull-model diagnostics (LSP 3.17). Each file is linted in isolation, so
+        // there are no inter-file dependencies and we don't offer workspace-wide
+        // pull. Push diagnostics (publishDiagnostics) remain for clients that use
+        // them; clients that support pull will prefer it and ignore the push.
+        diagnostic_provider: Some(DiagnosticServerCapabilities::Options(DiagnosticOptions {
+            identifier: Some(DIAGNOSTIC_SOURCE.to_string()),
+            inter_file_dependencies: false,
+            workspace_diagnostics: false,
+            work_done_progress_options: WorkDoneProgressOptions::default(),
+        })),
         ..ServerCapabilities::default()
     }
 }
@@ -148,6 +187,15 @@ fn dispatch_request(
                 return Ok(());
             };
             let result = completions::handle_completion(state, &params);
+            respond(connection, id, &result)?;
+        }
+        DocumentDiagnosticRequest::METHOD => {
+            let Some(params) =
+                parse_params::<DocumentDiagnosticParams>(connection, &id, request.params)?
+            else {
+                return Ok(());
+            };
+            let result = document_diagnostic_report(state, &params.text_document.uri);
             respond(connection, id, &result)?;
         }
         ExecuteCommand::METHOD => {
@@ -233,10 +281,49 @@ fn handle_execute_command(
     }
     state.reload_config();
 
-    // Refresh diagnostics for every open document under the new config.
+    // Refresh diagnostics for every open document under the new config (push
+    // model). Pull-model clients get a single refresh request instead.
     for uri in state.open_uris() {
         publish_diagnostics(connection, state, &uri)?;
     }
+    if state.diagnostic_refresh_support() {
+        request_diagnostic_refresh(connection, state)?;
+    }
+    Ok(())
+}
+
+/// Build a full diagnostic report for a pull (`textDocument/diagnostic`) request.
+/// This is the pull-shaped view of the same cached issues that `publish_diagnostics`
+/// pushes. Unknown (never-opened) documents report an empty set.
+fn document_diagnostic_report(state: &ServerState, uri: &Uri) -> DocumentDiagnosticReportResult {
+    let items = state
+        .document(uri)
+        .map(|document| issues_to_diagnostics(&document.issues, &document.text))
+        .unwrap_or_default();
+    DocumentDiagnosticReportResult::Report(DocumentDiagnosticReport::Full(
+        RelatedFullDocumentDiagnosticReport {
+            related_documents: None,
+            full_document_diagnostic_report: FullDocumentDiagnosticReport {
+                result_id: None,
+                items,
+            },
+        },
+    ))
+}
+
+/// Ask the client to re-pull all diagnostics. Sent after a project-wide change
+/// (e.g. disabling a rule) so pull-model clients see the new results. The client
+/// replies to this request; the main loop ignores that response.
+fn request_diagnostic_refresh(connection: &Connection, state: &mut ServerState) -> Result<()> {
+    let request = lsp_server::Request {
+        id: RequestId::from(state.next_request_id()),
+        method: WorkspaceDiagnosticRefresh::METHOD.to_string(),
+        params: serde_json::Value::Null,
+    };
+    connection
+        .sender
+        .send(Message::Request(request))
+        .context("failed to send diagnostic refresh request")?;
     Ok(())
 }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -19,8 +19,8 @@ mod state;
 use anyhow::{Context, Result};
 use lsp_server::{Connection, ErrorCode, Message, RequestId, Response, ResponseError};
 use lsp_types::notification::{
-    DidChangeTextDocument, DidCloseTextDocument, DidOpenTextDocument, Notification as _,
-    PublishDiagnostics, ShowMessage,
+    DidChangeTextDocument, DidCloseTextDocument, DidOpenTextDocument, LogMessage,
+    Notification as _, PublishDiagnostics, ShowMessage,
 };
 use lsp_types::request::{
     CodeActionRequest, Completion, DocumentDiagnosticRequest, ExecuteCommand, HoverRequest,
@@ -32,9 +32,9 @@ use lsp_types::{
     DidOpenTextDocumentParams, DocumentDiagnosticParams, DocumentDiagnosticReport,
     DocumentDiagnosticReportResult, ExecuteCommandOptions, ExecuteCommandParams,
     FullDocumentDiagnosticReport, HoverProviderCapability, InitializeParams, InitializeResult,
-    MessageType, PublishDiagnosticsParams, RelatedFullDocumentDiagnosticReport, ServerCapabilities,
-    ServerInfo, ShowMessageParams, TextDocumentSyncCapability, TextDocumentSyncKind, Uri,
-    WorkDoneProgressOptions,
+    LogMessageParams, MessageType, PublishDiagnosticsParams, RelatedFullDocumentDiagnosticReport,
+    ServerCapabilities, ServerInfo, ShowMessageParams, TextDocumentSyncCapability,
+    TextDocumentSyncKind, Uri, WorkDoneProgressOptions,
 };
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -80,6 +80,15 @@ pub fn serve(connection: &Connection) -> Result<()> {
 
     let mut state = ServerState::new(workspace_root(&init_params));
     state.set_diagnostic_refresh_support(client_supports_diagnostic_refresh(&init_params));
+    log_message(
+        connection,
+        MessageType::INFO,
+        format!(
+            "{} {} started",
+            env!("CARGO_PKG_NAME"),
+            env!("CARGO_PKG_VERSION")
+        ),
+    )?;
     main_loop(connection, &mut state)
 }
 
@@ -147,12 +156,20 @@ fn main_loop(connection: &Connection, state: &mut ServerState) -> Result<()> {
                 // tear down the whole session: log it and keep serving. The
                 // client has already received an error response where relevant.
                 if let Err(err) = dispatch_request(connection, state, request) {
-                    eprintln!("owui-lint: error handling request: {err:#}");
+                    let _ = log_message(
+                        connection,
+                        MessageType::ERROR,
+                        format!("error handling request: {err:#}"),
+                    );
                 }
             }
             Message::Notification(notification) => {
                 if let Err(err) = dispatch_notification(connection, state, notification) {
-                    eprintln!("owui-lint: error handling notification: {err:#}");
+                    let _ = log_message(
+                        connection,
+                        MessageType::ERROR,
+                        format!("error handling notification: {err:#}"),
+                    );
                 }
             }
             Message::Response(_) => {}
@@ -274,12 +291,17 @@ fn handle_execute_command(
     };
 
     if let Err(err) = disable_rule_in_config(root, rule_id) {
-        let message = format!("owui-lint: failed to update config to disable {rule_id}: {err}");
-        eprintln!("{message}");
+        let message = format!("failed to update config to disable {rule_id}: {err}");
+        log_message(connection, MessageType::ERROR, message.clone())?;
         show_message(connection, MessageType::ERROR, message)?;
         return Ok(());
     }
     state.reload_config();
+    log_message(
+        connection,
+        MessageType::INFO,
+        format!("disabled rule {rule_id}; reloaded config and re-linted open documents"),
+    )?;
 
     // Refresh diagnostics for every open document under the new config (push
     // model). Pull-model clients get a single refresh request instead.
@@ -332,6 +354,11 @@ fn publish_diagnostics(connection: &Connection, state: &ServerState, uri: &Uri) 
         return Ok(());
     };
     let diagnostics = issues_to_diagnostics(&document.issues, &document.text);
+    log_message(
+        connection,
+        MessageType::LOG,
+        format!("linted {}: {} finding(s)", uri.as_str(), diagnostics.len()),
+    )?;
     publish_for(connection, uri, diagnostics, Some(document.version))
 }
 
@@ -411,6 +438,23 @@ fn respond_error(
         .sender
         .send(Message::Response(response))
         .context("failed to send error response")?;
+    Ok(())
+}
+
+/// Send a `window/logMessage` notification. These land in the editor's output
+/// channel (e.g. the "owui-lint" panel in VS Code) and are filtered by the
+/// client's trace/log level, so they are the right place for operational logging
+/// (startup, lint summaries, recoverable errors) that should not pop a dialog.
+fn log_message(connection: &Connection, typ: MessageType, message: String) -> Result<()> {
+    let params = LogMessageParams { typ, message };
+    let notification = lsp_server::Notification {
+        method: LogMessage::METHOD.to_string(),
+        params: serde_json::to_value(params)?,
+    };
+    connection
+        .sender
+        .send(Message::Notification(notification))
+        .context("failed to send logMessage")?;
     Ok(())
 }
 

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -25,6 +25,13 @@ pub struct ServerState {
     documents: HashMap<Uri, Document>,
     root: Option<PathBuf>,
     config: Config,
+    /// Whether the client advertised `workspace.diagnostic.refreshSupport`, i.e.
+    /// it can handle a server-sent `workspace/diagnostic/refresh` request. Set
+    /// from the client capabilities during the initialize handshake.
+    diagnostic_refresh_support: bool,
+    /// Monotonic id source for requests the server sends to the client (e.g. the
+    /// diagnostic refresh request). JSON-RPC ids must be unique per connection.
+    next_request_id: i32,
 }
 
 impl ServerState {
@@ -38,7 +45,26 @@ impl ServerState {
             documents: HashMap::new(),
             root,
             config,
+            diagnostic_refresh_support: false,
+            next_request_id: 1,
         }
+    }
+
+    /// Record whether the client supports `workspace/diagnostic/refresh`.
+    pub fn set_diagnostic_refresh_support(&mut self, supported: bool) {
+        self.diagnostic_refresh_support = supported;
+    }
+
+    /// Whether the client can handle a server-sent diagnostic refresh request.
+    pub fn diagnostic_refresh_support(&self) -> bool {
+        self.diagnostic_refresh_support
+    }
+
+    /// Allocate the next unique id for a server-initiated request.
+    pub fn next_request_id(&mut self) -> i32 {
+        let id = self.next_request_id;
+        self.next_request_id += 1;
+        id
     }
 
     /// Read accessor for the active config. Linting now happens inside the state

--- a/tests/server_tests.rs
+++ b/tests/server_tests.rs
@@ -13,7 +13,7 @@ use lsp_types::{
     CodeActionResponse, Diagnostic, DiagnosticWorkspaceClientCapabilities,
     DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
     DocumentDiagnosticParams, DocumentDiagnosticReport, DocumentDiagnosticReportResult,
-    ExecuteCommandParams, InitializeParams, InitializeResult, NumberOrString,
+    ExecuteCommandParams, InitializeParams, InitializeResult, LogMessageParams, NumberOrString,
     PublishDiagnosticsParams, TextDocumentContentChangeEvent, TextDocumentIdentifier,
     TextDocumentItem, Uri, VersionedTextDocumentIdentifier, WorkspaceClientCapabilities,
 };
@@ -382,6 +382,34 @@ fn execute_command_requests_diagnostic_refresh_only_when_supported() {
         );
 
         shutdown(&client, server, 11);
+    }
+}
+
+/// The server reports operational events (startup, lint summaries, errors) via
+/// `window/logMessage`, which editors surface in their output channel.
+#[test]
+fn server_logs_startup_to_output_channel() {
+    let (client, server) = spawn_server();
+    handshake(&client, None);
+
+    let log = recv_log_message(&client);
+    assert!(
+        log.message.contains("owui-lint") && log.message.contains("started"),
+        "expected a startup log message, got {:?}",
+        log.message
+    );
+
+    shutdown(&client, server, 2);
+}
+
+/// Wait for the next `window/logMessage` notification and return its params.
+fn recv_log_message(client: &Connection) -> LogMessageParams {
+    loop {
+        if let Message::Notification(notification) = recv(client)
+            && notification.method == "window/logMessage"
+        {
+            return serde_json::from_value(notification.params).expect("logMessage params");
+        }
     }
 }
 

--- a/tests/server_tests.rs
+++ b/tests/server_tests.rs
@@ -9,11 +9,13 @@ use std::time::Duration;
 
 use lsp_server::{Connection, Message, Notification, Request, RequestId};
 use lsp_types::{
-    CodeAction, CodeActionContext, CodeActionOrCommand, CodeActionParams, CodeActionResponse,
-    Diagnostic, DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
-    ExecuteCommandParams, InitializeParams, NumberOrString, PublishDiagnosticsParams,
-    TextDocumentContentChangeEvent, TextDocumentIdentifier, TextDocumentItem, Uri,
-    VersionedTextDocumentIdentifier,
+    ClientCapabilities, CodeAction, CodeActionContext, CodeActionOrCommand, CodeActionParams,
+    CodeActionResponse, Diagnostic, DiagnosticWorkspaceClientCapabilities,
+    DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
+    DocumentDiagnosticParams, DocumentDiagnosticReport, DocumentDiagnosticReportResult,
+    ExecuteCommandParams, InitializeParams, InitializeResult, NumberOrString,
+    PublishDiagnosticsParams, TextDocumentContentChangeEvent, TextDocumentIdentifier,
+    TextDocumentItem, Uri, VersionedTextDocumentIdentifier, WorkspaceClientCapabilities,
 };
 
 const TOOLS_SOURCE: &str = "class Tools:\n    def search(self, query):\n        return query\n";
@@ -274,6 +276,115 @@ fn did_close_clears_diagnostics() {
     shutdown(&client, server, 3);
 }
 
+/// The initialize response must advertise `serverInfo` (so editors attribute the
+/// server) and the pull-model diagnostic provider (LSP 3.17).
+#[test]
+fn initialize_reports_server_info_and_diagnostic_provider() {
+    let (client, server) = spawn_server();
+
+    let init_id = RequestId::from(1);
+    send_request(
+        &client,
+        init_id.clone(),
+        "initialize",
+        InitializeParams::default(),
+    );
+    let result: InitializeResult =
+        serde_json::from_value(recv_response(&client, &init_id)).expect("initialize result");
+    send_notification(&client, "initialized", serde_json::json!({}));
+
+    let info = result.server_info.expect("serverInfo present");
+    assert_eq!(info.name, "owui-lint", "server name");
+    assert!(info.version.is_some(), "server version present");
+    assert!(
+        result.capabilities.diagnostic_provider.is_some(),
+        "pull-model diagnostics advertised"
+    );
+
+    shutdown(&client, server, 2);
+}
+
+/// A `textDocument/diagnostic` (pull) request returns a full report carrying the
+/// same findings the server pushes via `publishDiagnostics`.
+#[test]
+fn responds_to_pull_diagnostic_request() {
+    let (client, server) = spawn_server();
+    handshake(&client, None);
+
+    let uri = Uri::from_str("file:///tmp/owui_pull.py").expect("uri");
+    open_document(&client, &uri, TOOLS_SOURCE);
+    // Drain the diagnostics pushed on open; the pull request is what we assert on.
+    let _ = recv_publish(&client);
+
+    let diag_id = RequestId::from(20);
+    send_request(
+        &client,
+        diag_id.clone(),
+        "textDocument/diagnostic",
+        DocumentDiagnosticParams {
+            text_document: TextDocumentIdentifier { uri: uri.clone() },
+            identifier: None,
+            previous_result_id: None,
+            work_done_progress_params: Default::default(),
+            partial_result_params: Default::default(),
+        },
+    );
+
+    let report: DocumentDiagnosticReportResult =
+        serde_json::from_value(recv_response(&client, &diag_id)).expect("diagnostic report");
+    let items = match report {
+        DocumentDiagnosticReportResult::Report(DocumentDiagnosticReport::Full(full)) => {
+            full.full_document_diagnostic_report.items
+        }
+        other => panic!("expected a full report, got {other:?}"),
+    };
+    let codes = codes(&items);
+    assert!(codes.contains(&"OWT101".to_string()), "got {codes:?}");
+    assert!(codes.contains(&"OWT102".to_string()), "got {codes:?}");
+
+    shutdown(&client, server, 21);
+}
+
+/// When the client advertises `workspace.diagnostic.refreshSupport`, disabling a
+/// rule must trigger a server-sent `workspace/diagnostic/refresh` request so
+/// pull-model clients re-query. When it does not, no such request is sent.
+#[test]
+fn execute_command_requests_diagnostic_refresh_only_when_supported() {
+    for refresh_support in [true, false] {
+        let workspace = tempfile::tempdir().expect("temp workspace");
+        let (client, server) = spawn_server();
+        handshake_with_refresh(&client, workspace.path(), refresh_support);
+
+        let uri = Uri::from_str("file:///tmp/owui_refresh.py").expect("uri");
+        open_document(&client, &uri, TOOLS_SOURCE);
+        let _ = recv_publish(&client);
+
+        let command_id = RequestId::from(10);
+        send_request(
+            &client,
+            command_id.clone(),
+            "workspace/executeCommand",
+            ExecuteCommandParams {
+                command: "owui-lint.disableRule".to_string(),
+                arguments: vec![serde_json::Value::String("OWT102".to_string())],
+                work_done_progress_params: Default::default(),
+            },
+        );
+
+        // Collect every server->client request seen before the command response.
+        let requests = requests_until_response(&client, &command_id);
+        let sent_refresh = requests
+            .iter()
+            .any(|request| request.method == "workspace/diagnostic/refresh");
+        assert_eq!(
+            sent_refresh, refresh_support,
+            "refresh request presence should match client capability (support={refresh_support})"
+        );
+
+        shutdown(&client, server, 11);
+    }
+}
+
 fn diagnostic_code(diagnostic: &Diagnostic) -> Option<String> {
     match &diagnostic.code {
         Some(NumberOrString::String(code)) => Some(code.clone()),
@@ -319,6 +430,48 @@ fn handshake(client: &Connection, root: Option<&Path>) {
     send_request(client, init_id.clone(), "initialize", params);
     recv_response(client, &init_id);
     send_notification(client, "initialized", serde_json::json!({}));
+}
+
+/// Handshake advertising (or not) `workspace.diagnostic.refreshSupport`.
+fn handshake_with_refresh(client: &Connection, root: &Path, refresh_support: bool) {
+    let init_id = RequestId::from(1);
+    #[allow(deprecated)]
+    let params = InitializeParams {
+        root_uri: Some(file_uri(root)),
+        capabilities: ClientCapabilities {
+            workspace: Some(WorkspaceClientCapabilities {
+                diagnostic: Some(DiagnosticWorkspaceClientCapabilities {
+                    refresh_support: Some(refresh_support),
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    send_request(client, init_id.clone(), "initialize", params);
+    recv_response(client, &init_id);
+    send_notification(client, "initialized", serde_json::json!({}));
+}
+
+/// Drain messages until the response to `expected` arrives, returning every
+/// server->client request seen along the way (e.g. a diagnostic refresh).
+fn requests_until_response(client: &Connection, expected: &RequestId) -> Vec<Request> {
+    let mut requests = Vec::new();
+    loop {
+        match recv(client) {
+            Message::Response(response) => {
+                assert_eq!(
+                    &response.id, expected,
+                    "unexpected response id (awaited {expected:?}): {response:?}"
+                );
+                assert!(response.error.is_none(), "unexpected error: {response:?}");
+                return requests;
+            }
+            Message::Request(request) => requests.push(request),
+            Message::Notification(_) => {}
+        }
+    }
 }
 
 /// Open a document and let the server lint it.


### PR DESCRIPTION
## Summary

Brings the language server in line with the current **LSP 3.17** spec where it benefits a linter, adds operational logging surfaced in the editor, and documents how to wire owui-lint into common editors. Push-based behavior is unchanged — everything here is additive.

### Server (`src/server/`)
- **Pull-model diagnostics (3.17):** advertise `diagnosticProvider` and handle `textDocument/diagnostic`, reusing the existing `issues_to_diagnostics()` so push and pull share one source of truth. Each file is linted in isolation, so `interFileDependencies` and workspace pull are off.
- **Refresh on config change:** after a rule is disabled, send `workspace/diagnostic/refresh` when the client advertises `workspace.diagnostic.refreshSupport`, so pull clients re-query. The push refresh loop is kept for push clients.
- **`serverInfo`:** the initialize handshake now uses `initialize_start`/`initialize_finish` so the result reports `owui-lint` + version, and so client capabilities can be read.
- **`window/logMessage` logging:** startup banner, per-file lint summaries, config reload on rule disable, and recoverable errors that previously went to stderr now land in the editor's output channel (filtered by the client's log/trace level).

### VS Code extension (`editors/vscode/`)
- New command **owui-lint: Show Output** (`owui-lint.showOutput`) reveals the server's output channel. The existing `owui-lint.trace.server` setting already worked; now there's content to look at.

### Docs
- `editor-integration.md`: documented push/pull diagnostics, the Show Output command, `serverInfo`, and added copy-pasteable LSP setup guides for **Neovim** (built-in 0.11+ and nvim-lspconfig), **Vim** (vim-lsp, coc.nvim), **Helix**, **Sublime Text (LSP)**, and **Emacs (Eglot)**.
- `README.md`: noted push/pull diagnostics.

### Deliberately out of scope (no payoff for an open-buffer linter)
Workspace pull diagnostics, diagnostic tags / relatedInformation, codeAction/completionItem resolve, notebook/inlay/inline-value/type-hierarchy, and an explicit `positionEncoding` advert (we already use the UTF-16 default).

## Testing
- `cargo fmt -- --check`, `cargo clippy --locked --all-targets -- -D warnings`, `cargo test --locked` — all green (9 server tests, incl. pull diagnostics, refresh-iff-supported, serverInfo, and startup logging).
- `cargo run --bin docs-sync -- --check` and the Starlight docs build — green.
- `npm run compile` for the VS Code extension — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)