### PR TITLE
Fix: extension Server start and end

### DIFF
--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -1,1 +1,1 @@
-CHANGELOG.md
+../../CHANGELOG.md

--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -1,8 +1,1 @@
-# Changelog
-
-## 0.8.0
-
-- Adds live Open WebUI extension linting through the `owui-lint` language server.
-- Provides diagnostics, hover explanations, quick fixes, and completions for Open WebUI Tools, Pipes, Filters, Actions, and Pipelines.
-- Adds commands to restart the language server and show the extension output channel.
-
+CHANGELOG.md

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -72,6 +72,7 @@
         "owui-lint.path": {
           "type": "string",
           "default": "owui-lint",
+          "scope": "window",
           "markdownDescription": "Path to the `owui-lint` executable. Use `owui-lint` from `PATH`, an absolute path, a workspace-relative path such as `target/debug/owui-lint`, or `${workspaceFolder}/target/debug/owui-lint`."
         },
         "owui-lint.trace.server": {
@@ -82,6 +83,7 @@
             "verbose"
           ],
           "default": "off",
+          "scope": "window",
           "description": "Trace the communication between VS Code and the owui-lint language server."
         }
       }

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -1,124 +1,123 @@
 import * as vscode from "vscode";
-import { LanguageClient, LanguageClientOptions, ServerOptions, State } from 'vscode-languageclient/node';
+import {
+  LanguageClient,
+  LanguageClientOptions,
+  ServerOptions,
+} from "vscode-languageclient/node";
 
 let client: LanguageClient | undefined;
+let restartInFlight: Promise<void> | undefined;
 
-export function activate(context: vscode.ExtensionContext): void {
-  client = createClient();
+export async function activate(context: vscode.ExtensionContext): Promise<void> {
   context.subscriptions.push(
-    vscode.commands.registerCommand("owui-lint.restartServer", async () => {
-      await restart();
-    }),
-    // Reveal the server's output channel, where window/logMessage entries
-    // (startup, lint summaries, errors) and LSP message traces appear.
+    vscode.commands.registerCommand("owui-lint.restartServer", () => restart()),
     vscode.commands.registerCommand("owui-lint.showOutput", () => {
       client?.outputChannel.show();
     }),
+    vscode.workspace.onDidChangeConfiguration(async (event) => {
+      if (event.affectsConfiguration("owui-lint.path")) {
+        await restart();
+      }
+    }),
   );
-  void startClient(client);
+
+  await start();
 }
 
 export async function deactivate(): Promise<void> {
-  await stopClient(client);
+  const current = client;
   client = undefined;
+  if (current) {
+    await current.dispose();
+  }
 }
 
 function createClient(): LanguageClient {
-  const config = vscode.workspace.getConfiguration('owui-lint');
-  const command = resolveExecutablePath(config.get<string>('path', 'owui-lint'));
+  const config = vscode.workspace.getConfiguration("owui-lint");
+  const command = resolveExecutablePath(config.get<string>("path", "owui-lint"));
 
-  // owui-lint complements Pylance/Pyright; it only adds Open WebUI-specific
-  // diagnostics, hovers, quick-fixes and scaffolding snippets.
-  // Stdio is the default transport for an executable server. We intentionally
-  // omit an explicit `transport` so the client does not append a `--stdio`
-  // argument, which the owui-lint `server` subcommand does not require.
   const serverOptions: ServerOptions = {
-    run: { command, args: ['server'] },
-    debug: { command, args: ['server'] },
+    run: { command, args: ["server"] },
+    debug: { command, args: ["server"] },
   };
 
   const clientOptions: LanguageClientOptions = {
-    documentSelector: [{ scheme: 'file', language: 'python' }],
+    documentSelector: [{ scheme: "file", language: "python" }],
   };
 
-  return new LanguageClient('owui-lint', 'owui-lint', serverOptions, clientOptions);
+  return new LanguageClient("owui-lint", "owui-lint", serverOptions, clientOptions);
+}
+
+async function start(): Promise<void> {
+  const next = createClient();
+  client = next;
+
+  try {
+    await next.start();
+  } catch (error) {
+    if (client === next) {
+      client = undefined;
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    void vscode.window.showErrorMessage(
+      `owui-lint language server failed to start: ${message}`,
+    );
+  }
+}
+
+async function restart(): Promise<void> {
+  if (restartInFlight) {
+    return restartInFlight;
+  }
+
+  restartInFlight = (async () => {
+    const current = client;
+    client = undefined;
+    if (current) {
+      await current.dispose();
+    }
+    await start();
+  })().finally(() => {
+    restartInFlight = undefined;
+  });
+
+  return restartInFlight;
 }
 
 function resolveExecutablePath(configuredPath: string): string {
   const value = configuredPath.trim();
-  if (value === '' || value === 'owui-lint') {
-    return 'owui-lint';
+  if (value === "" || value === "owui-lint") {
+    return "owui-lint";
   }
 
   const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-  const expanded = workspaceFolder ? value.replaceAll('${workspaceFolder}', workspaceFolder) : value;
+  const expanded = workspaceFolder
+    ? value.replaceAll("${workspaceFolder}", workspaceFolder)
+    : value;
 
   if (isAbsolutePath(expanded)) {
     return expanded;
   }
 
   if (workspaceFolder && looksLikeRelativePath(expanded)) {
-    return vscode.Uri.joinPath(vscode.Uri.file(workspaceFolder), expanded.replace(/\\/g, '/')).fsPath;
+    return vscode.Uri.joinPath(
+      vscode.Uri.file(workspaceFolder),
+      expanded.replace(/\\/g, "/"),
+    ).fsPath;
   }
 
   return expanded;
 }
 
 function isAbsolutePath(value: string): boolean {
-  return value.startsWith('/') || /^[A-Za-z]:[\\/]/.test(value) || value.startsWith('\\\\');
+  return (
+    value.startsWith("/") ||
+    /^[A-Za-z]:[\\/]/.test(value) ||
+    value.startsWith("\\\\")
+  );
 }
 
 function looksLikeRelativePath(value: string): boolean {
-  return value.startsWith('.') || value.includes('/') || value.includes('\\');
+  return value.startsWith(".") || value.includes("/") || value.includes("\\");
 }
 
-async function restart(): Promise<void> {
-  await stopClient(client);
-  client = createClient();
-  void startClient(client);
-}
-
-async function startClient(languageClient: LanguageClient): Promise<void> {
-  try {
-    await languageClient.start();
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    void vscode.window.showErrorMessage(`owui-lint language server failed to start: ${message}`);
-  }
-}
-
-async function stopClient(languageClient: LanguageClient | undefined): Promise<void> {
-  if (!languageClient) {
-    return;
-  }
-
-  // If the client is starting, wait for it to reach Running state before stopping
-  if (languageClient.state === State.Starting) {
-    await new Promise<void>((resolve) => {
-      let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
-      let disposeListener: vscode.Disposable | undefined;
-
-      timeoutHandle = setTimeout(() => {
-        disposeListener?.dispose();
-        resolve();
-      }, 5000); // 5 second timeout
-
-      disposeListener = languageClient.onDidChangeState((event: { oldState: State; newState: State }) => {
-        if (event.newState === State.Running) {
-          if (timeoutHandle !== undefined) {
-            clearTimeout(timeoutHandle);
-          }
-          disposeListener?.dispose();
-          resolve();
-        }
-      });
-    });
-  }
-
-  // Only stop if the client is running
-  if (languageClient.state !== State.Running) {
-    return;
-  }
-
-  await languageClient.stop();
-}


### PR DESCRIPTION
## Summary

- Update Extension Code 
- Update vs Code setting scoped window 

## Type

- [x] `fix:` bug fix, patch release
- [ ] `feat:` new feature, minor release
- [ ] `docs:` documentation only
- [ ] `test:` tests only
- [ ] `chore:` / `ci:` maintenance, no release
- [ ] Breaking change: PR title uses `!` or description includes
      `BREAKING CHANGE:`

## Release Please

- [ ] PR title follows Conventional Commit style, for example
      `fix: handle missing valves block`.
- [ ] I did not manually bump versions unless this is release/version
      maintenance.
- [ ] If version metadata changed, I kept `Cargo.toml`, `Cargo.lock`,
      `.release-please-manifest.json`, `CHANGELOG.md`, and the VS Code
      extension (`editors/vscode/package.json`, `package-lock.json`) in sync.

## Tests

- [ ] Ran `cargo fmt -- --check` and `cargo clippy --locked -- -D warnings`.
- [ ] Ran `cargo test --locked` (and `make test-scripts` if scripts changed).
- [ ] Ran `make docs-check` if code or docs changed.
- [ ] Ran `npm ci --prefix editors/vscode && npm run vsix --prefix editors/vscode`
      if the VS Code extension changed.
- [ ] Added manual verification notes below if automated coverage is not
      practical.

## Verification

```text

```

## Notes

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extension now automatically restarts the language server when the linting path configuration changes.

* **Improvements**
  * Settings `owui-lint.path` and `owui-lint.trace.server` now support window-level scoping for per-window configuration.

* **Chores**
  * VS Code extension changelog consolidated to reference the repository root changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->